### PR TITLE
Refactor to use bleak & async

### DIFF
--- a/cometblue/__init__.py
+++ b/cometblue/__init__.py
@@ -286,16 +286,14 @@ class AsyncCometBlue:
         malformed
         """
         # validate values
-        if (
-            values[3] not in range(0, 100)
-            or values[2] not in range(1, 13)
-            or values[1] not in range(1, 31)
-            or values[0] not in range(0, 25)
-            or values[7] not in range(0, 100)
-            or values[6] not in range(1, 13)
-            or values[5] not in range(1, 31)
-            or values[4] not in range(0, 25)
-        ):
+        if values[3] not in range(0, 100) or \
+                values[2] not in range(1, 13) or \
+                values[1] not in range(1, 31) or \
+                values[0] not in range(0, 25) or \
+                values[7] not in range(0, 100) or \
+                values[6] not in range(1, 13) or \
+                values[5] not in range(1, 31) or \
+                values[4] not in range(0, 25):
             return dict()
 
         start = datetime(values[3] + 2000, values[2], values[1], values[0])
@@ -314,11 +312,7 @@ class AsyncCometBlue:
         :param values: dictionary containing start: datetime, end: datetime, temperature: float
         :return: bytearray to be transferred to the device
         """
-        if (
-            not values.__contains__("start")
-            or not values.__contains__("end")
-            or not values.__contains__("temperature")
-        ):
+        if not values.__contains__("start") or not values.__contains__("end") or not values.__contains__("temperature"):
             print("Nope")
             return bytearray(9)
 

--- a/cometblue/const.py
+++ b/cometblue/const.py
@@ -1,5 +1,6 @@
 # Bluetooth characteristics UUIDs
 from uuid import UUID
+
 SERVICE = "47e9ee00-47e9-11e4-8939-164230d1df67"
 
 CHARACTERISTIC_DATETIME = UUID("47e9ee01-47e9-11e4-8939-164230d1df67")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pygatt[GATTTOOL]==4.0.5
+bleak

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setuptools.setup(
         "Operating System :: POSIX :: Linux",
         "Development Status :: 5 - Production/Stable",
     ],
-    install_requires="pygatt[GATTTOOL]==4.0.5",
+    install_requires="bleak",
     python_requires='>=3.6',
 )


### PR DESCRIPTION
Hi, many thanks for this nicely fleshed out library!

I wanted to figure out if it can natively integrated with a Home Assistant component, but that requires `bleak` instead of `pygatt`, which again requires the base library to be `async`.

Therefore this PR introduces a `AsyncCometBlue` class as base the existing `CometBlue` inherits from.

This should allow it to continue running in any synchronous environment but also opens up new possibilies (such as the mentioned Home Assistant or Windows/MacOS compatibility).

While I was able to run the integrated tests successfully, it would be great if you could also check if these changes break nothing for your usecases.